### PR TITLE
[FIX] Issue #3

### DIFF
--- a/go_0023s/cp/cfns.h
+++ b/go_0023s/cp/cfns.h
@@ -6,6 +6,9 @@ __inline
 static unsigned int hash PARAMS ((const char *, unsigned int));
 #ifdef __GNUC__
 __inline
+#ifdef __GNUC_STDC_INLINE__
+__attribute__ ((__gnu_inline__))
+#endif
 #endif
 const char * libc_name_p PARAMS ((const char *, unsigned int));
 /* maximum key range = 1020, duplicates = 1 */
@@ -71,6 +74,9 @@ hash (str, len)
 
 #ifdef __GNUC__
 __inline
+#ifdef __GNUC_STDC_INLINE__
+__attribute__ ((__gnu_inline__))
+#endif
 #endif
 const char *
 libc_name_p (str, len)


### PR DESCRIPTION
gcc 7.1.1でGOのビルドが通らない問題(Issue #3)を修正しました．
参考：https://patchwork.ozlabs.org/patch/504982/