### PR TITLE
$(OKDIR) へインストールする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,29 +20,29 @@ all:
 install:
 	make all
 #	- mkdir ok
-	@if [ ! -d $(OKDIR) ]; then \
-		echo ";; mkdir $(OKDIR)"; mkdir $(OKDIR); \
+	@if [ ! -d "$(OKDIR)" ]; then \
+		echo ";; mkdir $(OKDIR)"; mkdir "$(OKDIR)"; \
 	fi
-	cp go_0023s/gcc/gocpp0 ok/
-	cp go_0023s/gcc/gocc1 ok/
-	cp go_0023s/gcc/gocc1plus ok/
-	cp go_0023s/toolstdc/golib00 ok/
-	cp go_0023s/toolstdc/sjisconv ok/
-	cp go_0023s/toolstdc/gas2nask ok/
-	cp go_0023s/toolstdc/nask ok/
-	cp go_0023s/toolstdc/naskcnv0 ok/
-	cp bim2bi4w/bim2bin ok/
-	cp bim2hrb/bim2hrb ok/
-	cp bin2obj0/bin2obj ok/
-	cp makefont/makefont ok/
-	cp edimg0j/edimg ok/
-	cp obj2bi4d/obj2bim ok/
-	cp t5lzma/t5lzma ok/
-	cp haritol/haritol ok/
-	cp multicmd/multicmd ok/
-	-mkdir ok/makeiso
-	cp fdimg2iso/fdimg2iso.dat ok/makeiso/
-	cp fdimg2iso/fdimg2iso ok/makeiso/
+	cp go_0023s/gcc/gocpp0 "$(OKDIR)/"
+	cp go_0023s/gcc/gocc1 "$(OKDIR)/"
+	cp go_0023s/gcc/gocc1plus "$(OKDIR)/"
+	cp go_0023s/toolstdc/golib00 "$(OKDIR)/"
+	cp go_0023s/toolstdc/sjisconv "$(OKDIR)/"
+	cp go_0023s/toolstdc/gas2nask "$(OKDIR)/"
+	cp go_0023s/toolstdc/nask "$(OKDIR)/"
+	cp go_0023s/toolstdc/naskcnv0 "$(OKDIR)/"
+	cp bim2bi4w/bim2bin "$(OKDIR)/"
+	cp bim2hrb/bim2hrb "$(OKDIR)/"
+	cp bin2obj0/bin2obj "$(OKDIR)/"
+	cp makefont/makefont "$(OKDIR)/"
+	cp edimg0j/edimg "$(OKDIR)/"
+	cp obj2bi4d/obj2bim "$(OKDIR)/"
+	cp t5lzma/t5lzma "$(OKDIR)/"
+	cp haritol/haritol "$(OKDIR)/"
+	cp multicmd/multicmd "$(OKDIR)/"
+	-mkdir "$(OKDIR)/makeiso"
+	cp fdimg2iso/fdimg2iso.dat "$(OKDIR)/makeiso/"
+	cp fdimg2iso/fdimg2iso "$(OKDIR)/makeiso/"
 
 
 clean :
@@ -58,7 +58,7 @@ clean :
 	$(MAKEC) haritol clean
 	$(MAKEC) multicmd clean
 	$(MAKEC) fdimg2iso clean
-	rm -rf ok/*
+	rm -rf "$(OKDIR)/"*
 
 
 


### PR DESCRIPTION
Makefile 中で、インストール先フォルダは `$(OKDIR)` として設定するようになっているように見えるものの実際には `ok/` としてハードコーディングされていたので、`$(OKDIR)` を使うようにしました。
